### PR TITLE
Allow kwdef macro outside of definition of struct

### DIFF
--- a/src/ProtoStruct.jl
+++ b/src/ProtoStruct.jl
@@ -1,7 +1,6 @@
 macro proto( expr )
 
-    if expr.head == :macrocall
-        expr = quote $(expr.args[2:end]...) end
+    if (expr.head == :macrocall) & (expr.args[1] == Symbol("@kwdef"))
         expr = expr.args[3]
     end
 
@@ -147,5 +146,3 @@ macro proto( expr )
         end
     ex |> esc
 end # macro
-
-

--- a/src/ProtoStruct.jl
+++ b/src/ProtoStruct.jl
@@ -1,5 +1,5 @@
 macro proto( expr )
-    if (expr.head == :macrocall) & (expr.args[1] == Symbol("@kwdef"))
+    if expr.head == :macrocall && expr.args[1] == Symbol("@kwdef")
         expr = expr.args[3]
     end
 

--- a/src/ProtoStruct.jl
+++ b/src/ProtoStruct.jl
@@ -1,5 +1,4 @@
 macro proto( expr )
-
     if (expr.head == :macrocall) & (expr.args[1] == Symbol("@kwdef"))
         expr = expr.args[3]
     end

--- a/src/ProtoStruct.jl
+++ b/src/ProtoStruct.jl
@@ -1,4 +1,10 @@
 macro proto( expr )
+
+    if expr.head == :macrocall
+        expr = quote $(expr.args[2:end]...) end
+        expr = expr.args[3]
+    end
+
     if expr.head != Symbol("struct")
         throw(ArgumentError("Expected expression to be a type definition."))
     end

--- a/test/test_ProtoStruct.jl
+++ b/test/test_ProtoStruct.jl
@@ -57,6 +57,16 @@ end
     @test tw.E == "yepp"
 end
 
+@proto @kwdef struct TestMacroOutside
+    A::Int = 1
+end
+
+@testset "@kwdef macro outside" begin
+    tw = TestMacroOutside()
+    @test tw isa TestMacroOutside
+    @test tw.A == 1
+end
+
 @proto mutable struct TestMutation{T, V <: Real}
     A::Int = 1
     B = :no


### PR DESCRIPTION
Fixes #15 

Maybe too hard coded as removal, will improve that

