### PR TITLE
Allow Abstract Type definitions

### DIFF
--- a/src/ProtoStruct.jl
+++ b/src/ProtoStruct.jl
@@ -1,6 +1,4 @@
 
-abstract type AbstractProto end
-
 macro proto( expr )
     if expr.head != Symbol("struct")
         throw(ArgumentError("Expected expression to be a type definition."))
@@ -13,7 +11,7 @@ macro proto( expr )
         abstract_type = name.args[2]
         name = name.args[1]
     else
-        abstract_type = :(ProtoStructs.AbstractProto)
+        abstract_type = :(Any)
     end
 
     type_parameters = nothing

--- a/src/ProtoStruct.jl
+++ b/src/ProtoStruct.jl
@@ -1,3 +1,6 @@
+
+abstract type AbstractProto end
+
 macro proto( expr )
     if expr.head != Symbol("struct")
         throw(ArgumentError("Expected expression to be a type definition."))
@@ -9,6 +12,8 @@ macro proto( expr )
     if name.head == :<:
         abstract_type = name.args[2]
         name = name.args[1]
+    else
+        abstract_type = :(ProtoStructs.AbstractProto)
     end
 
     type_parameters = nothing

--- a/src/ProtoStruct.jl
+++ b/src/ProtoStruct.jl
@@ -5,6 +5,12 @@ macro proto( expr )
     ismutable = expr.args[1]
 
     name = expr.args[2]
+
+    if name.head == :<:
+        abstract_type = name.args[2]
+        name = name.args[1]
+    end
+
     type_parameters = nothing
     type_parameter_names = []
     type_parameter_types = []
@@ -72,7 +78,7 @@ macro proto( expr )
     ex = if ismutable
             quote
                 if !@isdefined $name
-                    struct $name{AD<:AbstractDict}
+                    struct $name{AD<:AbstractDict} <: $abstract_type
                         properties::AD
                     end # struct
                 else
@@ -109,7 +115,7 @@ macro proto( expr )
         else
             quote
                 if !@isdefined $name
-                    struct $name{NT<:NamedTuple}
+                    struct $name{NT<:NamedTuple} <: $abstract_type
                         properties::NT
                     end # struct
                 else

--- a/src/ProtoStruct.jl
+++ b/src/ProtoStruct.jl
@@ -11,7 +11,7 @@ macro proto( expr )
 
     name = expr.args[2]
 
-    if name.head == :<:
+    if !(name isa Symbol) && name.head == :<:
         abstract_type = name.args[2]
         name = name.args[1]
     else

--- a/test/test_ProtoStruct.jl
+++ b/test/test_ProtoStruct.jl
@@ -102,5 +102,5 @@ end
     @test tpm.C === nothing
     @test tpm.D == 1.2
     @test tpm.E == "nope"
-    @test TestMutation <: AbstractMutation
+    @test TestParametricMutation <: AbstractMutation
 end

--- a/test/test_ProtoStruct.jl
+++ b/test/test_ProtoStruct.jl
@@ -57,7 +57,9 @@ end
     @test tw.E == "yepp"
 end
 
-@proto mutable struct TestMutation{T, V <: Real}
+abstract type AbstractMutation end
+
+@proto mutable struct TestMutation{T, V <: Real} <: AbstractMutation
     A::Int = 1
     B = :no
     C::T = nothing
@@ -76,4 +78,5 @@ end
     @test tm.C === nothing
     @test tm.D == 1.2
     @test tm.E == "nope"
+    @test TestMutation <: AbstractMutation
 end


### PR DESCRIPTION
Fixes #20 

No warning when doing 

```julia
@proto mutable struct A <: Integer
           F::Int
       end
```

and it works

```julia
julia> A <: Integer
true
```