### PR TITLE
Allow parametric construction and inheritance

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.experimental }}
     strategy:
-      fail-fast: false
       matrix:
         julia-version: ['1.6', '1']
         julia-arch: [x64, x86]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,7 @@ jobs:
   test:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         julia-version: ['1.6', '1', 'nightly']
         julia-arch: [x64, x86]

--- a/src/ProtoStruct.jl
+++ b/src/ProtoStruct.jl
@@ -130,6 +130,10 @@ macro proto( expr )
                 function Base.propertynames( o::$name )
                     return propertynames( getfield(o, :properties) )
                 end # function
+
+                function Base.show(io::IO, o::$name{$(type_parameters...)}) where {$(type_parameters...)}
+                    print(io, $name{$(type_parameters...)}, "($(getfield(o, :properties)...))")
+                end
             end
         else
             quote
@@ -168,6 +172,10 @@ macro proto( expr )
                 function Base.propertynames( o::$name )
                     return propertynames( getfield(o, :properties) )
                 end # function
+
+                function Base.show(io::IO, o::$name{$(type_parameters...)}) where {$(type_parameters...)}
+                    print(io, $name{$(type_parameters...)}, "($(getfield(o, :properties)...))")
+                end
             end # quote
         end
     ex |> esc

--- a/src/ProtoStruct.jl
+++ b/src/ProtoStruct.jl
@@ -110,7 +110,12 @@ macro proto( expr )
                 )
 
                 function $name($(fields...)) where {$(type_parameters...)} 
-                    v = NamedTuple{$field_names, $field_types}(($(field_names...),))
+                    v = NamedTuple{$field_names, $field_types}(($(fields_with_ref...),))
+                    return $name{$(type_parameter_names...), typeof(v)}(v)
+                end
+
+                function $name{$(type_parameter_names...)}($(fields...)) where {$(type_parameters...)} 
+                    v = NamedTuple{$field_names, $field_types}(($(fields_with_ref...),))
                     return $name{$(type_parameter_names...), typeof(v)}(v)
                 end
 
@@ -155,6 +160,10 @@ macro proto( expr )
                     return $name{$(type_parameter_names...), typeof(v)}(v)
                 end
 
+                function $name{$(type_parameter_names...)}($(fields...)) where {$(type_parameters...)} 
+                    v = NamedTuple{$field_names, $field_types}(($(field_names...),))
+                    return $name{$(type_parameter_names...), typeof(v)}(v)
+                end
                 function $name($params_ex)
                     $name($(call_args...))
                 end

--- a/src/ProtoStruct.jl
+++ b/src/ProtoStruct.jl
@@ -7,7 +7,7 @@ macro proto(expr)
     if expr.head != Symbol("struct")
         throw(ArgumentError("Expected expression to be a type definition."))
     end
-    
+
     ismutable = expr.args[1]
     name = expr.args[2]
 
@@ -115,21 +115,21 @@ macro proto(expr)
                     Base.delete_method(the_methods[2])
                 end
 
-                function $name($(fields...)) where {$(type_parameters...)} 
+                function $name($(fields...)) where {$(type_parameters...)}
                     v = NamedTuple{$field_names, $field_types}(($(fields_with_ref...),))
                     return $name{$(type_parameter_names...), $(any_params...), typeof(v)}(v)
                 end
 
-                function $name{$(type_parameter_names...)}($(fields...)) where {$(type_parameters...)} 
+                function $name{$(type_parameter_names...)}($(fields...)) where {$(type_parameters...)}
                     v = NamedTuple{$field_names, $field_types}(($(fields_with_ref...),))
                     return $name{$(type_parameter_names...), $(any_params...), typeof(v)}(v)
                 end
-            
+
                 function $name($params_ex)
                     return $name($(call_args...))
                 end
 
-                function $name{$(type_parameter_names...)}($params_ex) where {$(type_parameters...)} 
+                function $name{$(type_parameter_names...)}($params_ex) where {$(type_parameters...)}
                     $name{$(type_parameter_names...)}($(call_args...))
                 end
 
@@ -148,9 +148,14 @@ macro proto(expr)
                     return propertynames(getfield(o, :properties))
                 end
 
-                function Base.show(io::IO, o::$name{$(type_parameter_names...)}) where {$(type_parameters...)}
+                function Base.show(io::IO, o::$name)
                     vals = join([x[] isa String ? "\"$(x[])\"" : x[] for x in getfield(o, :properties)], ", ")
-                    print(io, $name{$(type_parameter_names...)}, "($vals)")
+                    params = typeof(o).parameters[1:end-$N_any_params-1]
+                    if isempty(params)
+                        print(io, string($name), "($vals)")
+                    else
+                        print(io, string($name, "{", join(params, ", "), "}"), "($vals)")
+                    end
                 end
             end
         else
@@ -165,24 +170,24 @@ macro proto(expr)
                     Base.delete_method(the_methods[2])
                 end
 
-                function $name($(fields...)) where {$(type_parameters...)} 
+                function $name($(fields...)) where {$(type_parameters...)}
                     v = NamedTuple{$field_names, $field_types}(($(field_names...),))
                     return $name{$(type_parameter_names...), $(any_params...), typeof(v)}(v)
                 end
 
-                function $name{$(type_parameter_names...)}($(fields...)) where {$(type_parameters...)} 
+                function $name{$(type_parameter_names...)}($(fields...)) where {$(type_parameters...)}
                     v = NamedTuple{$field_names, $field_types}(($(field_names...),))
                     return $name{$(type_parameter_names...), $(any_params...), typeof(v)}(v)
                 end
-            
+
                 function $name($params_ex)
                     return $name($(call_args...))
                 end
-            
-                function $name{$(type_parameter_names...)}($params_ex) where {$(type_parameters...)} 
+
+                function $name{$(type_parameter_names...)}($params_ex) where {$(type_parameters...)}
                     $name{$(type_parameter_names...)}($(call_args...))
                 end
-            
+
                 function Base.getproperty(o::$name, s::Symbol)
                     return getproperty(getfield(o, :properties), s)
                 end
@@ -191,9 +196,14 @@ macro proto(expr)
                     return propertynames(getfield(o, :properties))
                 end
 
-                function Base.show(io::IO, o::$name{$(type_parameter_names...)}) where {$(type_parameters...)}
+                function Base.show(io::IO, o::$name)
                     vals = join([x isa String ? "\"$x\"" : x for x in getfield(o, :properties)], ", ")
-                    print(io, $name{$(type_parameter_names...)}, "($vals)")
+                    params = typeof(o).parameters[1:end-$N_any_params-1]
+                    if isempty(params)
+                        print(io, string($name), "($vals)")
+                    else
+                        print(io, string($name, "{", join(params, ", "), "}"), "($vals)")
+                    end
                 end
             end
         end

--- a/src/ProtoStruct.jl
+++ b/src/ProtoStruct.jl
@@ -101,8 +101,6 @@ macro proto( expr )
                     Base.delete_method(the_methods[2])
                 end
 
-                $name($(fields...)) where {$(type_parameters...)} = $name(NamedTuple{$field_names, $field_types}(($(fields_with_ref...),)))
-
                 function $name($(fields...)) where {$(type_parameters...)} 
                     v = NamedTuple{$field_names, $field_types}(($(fields_with_ref...),))
                     return $name{$(type_parameter_names...), typeof(v)}(v)
@@ -144,8 +142,6 @@ macro proto( expr )
                     Base.delete_method(the_methods[1])
                     Base.delete_method(the_methods[2])
                 end
-
-                $name($(fields...)) where {$(type_parameters...)} = $name(NamedTuple{$field_names, $field_types}(($(field_names...),)))
 
                 function $name($(fields...)) where {$(type_parameters...)} 
                     v = NamedTuple{$field_names, $field_types}(($(field_names...),))

--- a/src/ProtoStruct.jl
+++ b/src/ProtoStruct.jl
@@ -151,9 +151,6 @@ macro proto(expr)
                 function Base.show(io::IO, o::$name{$(type_parameter_names...)}) where {$(type_parameters...)}
                     vals = join([x[] isa String ? "\"$(x[])\"" : x[] for x in getfield(o, :properties)], ", ")
                     print(io, $name{$(type_parameter_names...)}, "($vals)")
-
-                function Base.propertynames(o::$name)
-                    return propertynames(getfield(o, :properties))
                 end
             end
         else

--- a/src/ProtoStruct.jl
+++ b/src/ProtoStruct.jl
@@ -101,7 +101,7 @@ macro proto( expr )
                     Base.delete_method(the_methods[2])
                 end
 
-                $name($(fields...)) where {$(type_parameters...)} = $name(NamedTuple{$field_names, $field_types}(($(fields_with_ref...),))) )
+                $name($(fields...)) where {$(type_parameters...)} = $name(NamedTuple{$field_names, $field_types}(($(fields_with_ref...),)))
 
                 function $name($(fields...)) where {$(type_parameters...)} 
                     v = NamedTuple{$field_names, $field_types}(($(fields_with_ref...),))
@@ -145,7 +145,7 @@ macro proto( expr )
                     Base.delete_method(the_methods[2])
                 end
 
-                $name($(fields...)) where {$(type_parameters...)} = $name(NamedTuple{$field_names, $field_types}(($(field_names...),))) )
+                $name($(fields...)) where {$(type_parameters...)} = $name(NamedTuple{$field_names, $field_types}(($(field_names...),)))
 
                 function $name($(fields...)) where {$(type_parameters...)} 
                     v = NamedTuple{$field_names, $field_types}(($(field_names...),))

--- a/src/ProtoStruct.jl
+++ b/src/ProtoStruct.jl
@@ -183,11 +183,11 @@ macro proto(expr)
                     $name{$(type_parameter_names...)}($(call_args...))
                 end
             
-                function Base.getproperty( o::$name, s::Symbol )
+                function Base.getproperty(o::$name, s::Symbol)
                     return getproperty(getfield(o, :properties), s)
                 end
 
-                function Base.propertynames( o::$name )
+                function Base.propertynames(o::$name)
                     return propertynames(getfield(o, :properties))
                 end
 

--- a/src/ProtoStruct.jl
+++ b/src/ProtoStruct.jl
@@ -187,11 +187,11 @@ macro proto(expr)
                 end
             
                 function Base.getproperty( o::$name, s::Symbol )
-                    return getproperty( getfield(o, :properties), s )
+                    return getproperty(getfield(o, :properties), s)
                 end
 
                 function Base.propertynames( o::$name )
-                    return propertynames( getfield(o, :properties) )
+                    return propertynames(getfield(o, :properties))
                 end
 
                 function Base.show(io::IO, o::$name{$(type_parameter_names...)}) where {$(type_parameters...)}

--- a/src/ProtoStruct.jl
+++ b/src/ProtoStruct.jl
@@ -132,7 +132,7 @@ macro proto( expr )
                 end # function
 
                 function Base.show(io::IO, o::$name{$(type_parameter_names...)}) where {$(type_parameters...)}
-                    vals = join([x[] for x in getfield(a, :properties)], ", ")
+                    vals = join([x[] for x in getfield(o, :properties)], ", ")
                     print(io, $name{$(type_parameter_names...)}, "($vals)")
                 end
             end
@@ -175,7 +175,7 @@ macro proto( expr )
                 end # function
 
                 function Base.show(io::IO, o::$name{$(type_parameter_names...)}) where {$(type_parameters...)}
-                    vals = join(getfield(a, :properties), ", ")
+                    vals = join(getfield(o, :properties), ", ")
                     print(io, $name{$(type_parameter_names...)}, "($vals)")
                 end
             end # quote

--- a/src/ProtoStruct.jl
+++ b/src/ProtoStruct.jl
@@ -132,7 +132,8 @@ macro proto( expr )
                 end # function
 
                 function Base.show(io::IO, o::$name{$(type_parameter_names...)}) where {$(type_parameters...)}
-                    print(io, $name{$(type_parameter_names...)}, "($(getfield(o, :properties)...))")
+                    vals = join([x[] for x in getfield(a, :properties)], ", ")
+                    print(io, $name{$(type_parameter_names...)}, "($vals)")
                 end
             end
         else

--- a/src/ProtoStruct.jl
+++ b/src/ProtoStruct.jl
@@ -89,10 +89,15 @@ macro proto( expr )
         ex
     end
 
+    default_params = [Symbol("P", i) for i in 1:10]
+    N_any_params = length(default_params) - length(type_parameter_names)
+    N_any_params <= 0 && error("The number of parameters of the proto struct is too high")
+    any_params = [:(Any) for _ in 1:N_any_params]
+
     ex = if ismutable
             quote
                 if !@isdefined $name
-                    struct $name{$(type_parameters...), NT<:NamedTuple} <: $abstract_type
+                    struct $name{$(default_params...), NT<:NamedTuple} <: $abstract_type
                         properties::NT
                     end
                 else
@@ -103,12 +108,12 @@ macro proto( expr )
 
                 function $name($(fields...)) where {$(type_parameters...)} 
                     v = NamedTuple{$field_names, $field_types}(($(fields_with_ref...),))
-                    return $name{$(type_parameter_names...), typeof(v)}(v)
+                    return $name{$(type_parameter_names...), $(any_params...), typeof(v)}(v)
                 end
 
                 function $name{$(type_parameter_names...)}($(fields...)) where {$(type_parameters...)} 
                     v = NamedTuple{$field_names, $field_types}(($(fields_with_ref...),))
-                    return $name{$(type_parameter_names...), typeof(v)}(v)
+                    return $name{$(type_parameter_names...), $(any_params...), typeof(v)}(v)
                 end
             
                 function $name($params_ex)
@@ -139,7 +144,7 @@ macro proto( expr )
         else
             quote
                 if !@isdefined $name
-                    struct $name{$(type_parameters...), NT<:NamedTuple} <: $abstract_type
+                    struct $name{$(default_params...), NT<:NamedTuple} <: $abstract_type
                         properties::NT
                     end
                 else
@@ -150,12 +155,12 @@ macro proto( expr )
 
                 function $name($(fields...)) where {$(type_parameters...)} 
                     v = NamedTuple{$field_names, $field_types}(($(field_names...),))
-                    return $name{$(type_parameter_names...), typeof(v)}(v)
+                    return $name{$(type_parameter_names...), $(any_params...), typeof(v)}(v)
                 end
 
                 function $name{$(type_parameter_names...)}($(fields...)) where {$(type_parameters...)} 
                     v = NamedTuple{$field_names, $field_types}(($(field_names...),))
-                    return $name{$(type_parameter_names...), typeof(v)}(v)
+                    return $name{$(type_parameter_names...), $(any_params...), typeof(v)}(v)
                 end
             
                 function $name($params_ex)

--- a/src/ProtoStruct.jl
+++ b/src/ProtoStruct.jl
@@ -89,7 +89,7 @@ macro proto( expr )
         ex
     end
 
-    default_params = [Symbol("P", i) for i in 1:10]
+    default_params = [Symbol("P", i) for i in 1:15]
     N_any_params = length(default_params) - length(type_parameter_names)
     N_any_params <= 0 && error("The number of parameters of the proto struct is too high")
     any_params = [:(Any) for _ in 1:N_any_params]

--- a/src/ProtoStruct.jl
+++ b/src/ProtoStruct.jl
@@ -118,8 +118,12 @@ macro proto( expr )
                     v = NamedTuple{$field_names, $field_types}(($(fields_with_ref...),))
                     return $name{$(type_parameter_names...), typeof(v)}(v)
                 end
-
+            
                 function $name($params_ex)
+                    $name($(call_args...))
+                end
+
+                function $name{$(type_parameter_names...)}($params_ex) where {$(type_parameters...)} 
                     $name($(call_args...))
                 end
 
@@ -164,10 +168,15 @@ macro proto( expr )
                     v = NamedTuple{$field_names, $field_types}(($(field_names...),))
                     return $name{$(type_parameter_names...), typeof(v)}(v)
                 end
+            
                 function $name($params_ex)
                     $name($(call_args...))
                 end
-
+            
+                function $name{$(type_parameter_names...)}($params_ex) where {$(type_parameters...)} 
+                    $name($(call_args...))
+                end
+            
                 function Base.getproperty( o::$name, s::Symbol )
                     return getproperty( getfield(o, :properties), s )
                 end # function

--- a/src/ProtoStruct.jl
+++ b/src/ProtoStruct.jl
@@ -18,7 +18,7 @@ macro proto( expr )
         abstract_type = :(Any)
     end
 
-    type_parameters = nothing
+    type_parameters = []
     type_parameter_names = []
     type_parameter_types = []
     if !(name isa Symbol)

--- a/src/ProtoStruct.jl
+++ b/src/ProtoStruct.jl
@@ -92,7 +92,7 @@ macro proto( expr )
     ex = if ismutable
             quote
                 if !@isdefined $name
-                    struct $name{NT<:NamedTuple} <: $abstract_type
+                    struct $name{P1, P2, NT<:NamedTuple} <: $abstract_type
                         properties::NT
                     end # struct
                 else
@@ -108,6 +108,21 @@ macro proto( expr )
                         :( $name($(fields...)) where {$(type_parameters...)} = $name(NamedTuple{$field_names, $field_types}(($(fields_with_ref...),))) )
                     end
                 )
+
+                function $name($(fields...)) where {$(type_parameters...)} 
+                    v = NamedTuple{$field_names, $field_types}(($(field_names...),))
+                    return $name{Any, Any, typeof(v)}(v)
+                end
+
+                function $name{P1}($(fields...)) where {P1,$(type_parameters...)} 
+                    v = NamedTuple{$field_names, $field_types}(($(field_names...),))
+                    return $name{P1, Any, typeof(v)}(v)
+                end
+
+                function $name{P1,P2}($(fields...)) where {P1,P2,$(type_parameters...)} 
+                    v = NamedTuple{$field_names, $field_types}(($(field_names...),))
+                    return $name{P1, P2, typeof(v)}(v)
+                end
 
                 function $name($params_ex)
                     $name($(call_args...))
@@ -128,7 +143,7 @@ macro proto( expr )
         else
             quote
                 if !@isdefined $name
-                    struct $name{NT<:NamedTuple} <: $abstract_type
+                    struct $name{P1, P2, NT<:NamedTuple} <: $abstract_type
                         properties::NT
                     end # struct
                 else
@@ -144,6 +159,21 @@ macro proto( expr )
                         :( $name($(fields...)) where {$(type_parameters...)} = $name(NamedTuple{$field_names, $field_types}(($(field_names...),))) )
                     end
                 )
+
+                function $name($(fields...)) where {$(type_parameters...)} 
+                    v = NamedTuple{$field_names, $field_types}(($(field_names...),))
+                    return $name{Any, Any, typeof(v)}(v)
+                end
+
+                function $name{P1}($(fields...)) where {P1,$(type_parameters...)} 
+                    v = NamedTuple{$field_names, $field_types}(($(field_names...),))
+                    return $name{P1, Any, typeof(v)}(v)
+                end
+
+                function $name{P1,P2}($(fields...)) where {P1,P2,$(type_parameters...)} 
+                    v = NamedTuple{$field_names, $field_types}(($(field_names...),))
+                    return $name{P1, P2, typeof(v)}(v)
+                end
 
                 function $name($params_ex)
                     $name($(call_args...))

--- a/src/ProtoStruct.jl
+++ b/src/ProtoStruct.jl
@@ -101,13 +101,7 @@ macro proto( expr )
                     Base.delete_method(the_methods[2])
                 end
 
-                $(
-                    if type_parameters === nothing
-                        :( $name(args...) = $name(NamedTuple{$field_names, $field_types}(Ref.(args))) )
-                    else
-                        :( $name($(fields...)) where {$(type_parameters...)} = $name(NamedTuple{$field_names, $field_types}(($(fields_with_ref...),))) )
-                    end
-                )
+                $name($(fields...)) where {$(type_parameters...)} = $name(NamedTuple{$field_names, $field_types}(($(fields_with_ref...),))) )
 
                 function $name($(fields...)) where {$(type_parameters...)} 
                     v = NamedTuple{$field_names, $field_types}(($(fields_with_ref...),))
@@ -151,13 +145,7 @@ macro proto( expr )
                     Base.delete_method(the_methods[2])
                 end
 
-                $(
-                    if type_parameters === nothing
-                        :( $name(args...) = $name(NamedTuple{$field_names, $field_types}(args)) )
-                    else
-                        :( $name($(fields...)) where {$(type_parameters...)} = $name(NamedTuple{$field_names, $field_types}(($(field_names...),))) )
-                    end
-                )
+                $name($(fields...)) where {$(type_parameters...)} = $name(NamedTuple{$field_names, $field_types}(($(field_names...),))) )
 
                 function $name($(fields...)) where {$(type_parameters...)} 
                     v = NamedTuple{$field_names, $field_types}(($(field_names...),))

--- a/src/ProtoStruct.jl
+++ b/src/ProtoStruct.jl
@@ -124,7 +124,7 @@ macro proto( expr )
                 end
 
                 function $name{$(type_parameter_names...)}($params_ex) where {$(type_parameters...)} 
-                    $name($(call_args...))
+                    $name{$(type_parameter_names...)}($(call_args...))
                 end
 
                 function Base.getproperty( o::$name, s::Symbol )
@@ -174,7 +174,7 @@ macro proto( expr )
                 end
             
                 function $name{$(type_parameter_names...)}($params_ex) where {$(type_parameters...)} 
-                    $name($(call_args...))
+                    $name{$(type_parameter_names...)}($(call_args...))
                 end
             
                 function Base.getproperty( o::$name, s::Symbol )

--- a/src/ProtoStruct.jl
+++ b/src/ProtoStruct.jl
@@ -132,7 +132,7 @@ macro proto( expr )
                 end # function
 
                 function Base.show(io::IO, o::$name{$(type_parameter_names...)}) where {$(type_parameters...)}
-                    vals = join([x[] for x in getfield(o, :properties)], ", ")
+                    vals = join([x[] isa String ? "\"$(x[])\"" : x[] for x in getfield(o, :properties)], ", ")
                     print(io, $name{$(type_parameter_names...)}, "($vals)")
                 end
             end
@@ -175,7 +175,7 @@ macro proto( expr )
                 end # function
 
                 function Base.show(io::IO, o::$name{$(type_parameter_names...)}) where {$(type_parameters...)}
-                    vals = join(getfield(o, :properties), ", ")
+                    vals = join([x isa String ? "\"$x\"" : x for x in getfield(o, :properties)], ", ")
                     print(io, $name{$(type_parameter_names...)}, "($vals)")
                 end
             end # quote

--- a/src/ProtoStruct.jl
+++ b/src/ProtoStruct.jl
@@ -131,8 +131,8 @@ macro proto( expr )
                     return propertynames( getfield(o, :properties) )
                 end # function
 
-                function Base.show(io::IO, o::$name{$(type_parameters...)}) where {$(type_parameters...)}
-                    print(io, $name{$(type_parameters...)}, "($(getfield(o, :properties)...))")
+                function Base.show(io::IO, o::$name{$(type_parameter_names...)}) where {$(type_parameters...)}
+                    print(io, $name{$(type_parameter_names...)}, "($(getfield(o, :properties)...))")
                 end
             end
         else
@@ -173,8 +173,8 @@ macro proto( expr )
                     return propertynames( getfield(o, :properties) )
                 end # function
 
-                function Base.show(io::IO, o::$name{$(type_parameters...)}) where {$(type_parameters...)}
-                    print(io, $name{$(type_parameters...)}, "($(getfield(o, :properties)...))")
+                function Base.show(io::IO, o::$name{$(type_parameter_names...)}) where {$(type_parameters...)}
+                    print(io, $name{$(type_parameter_names...)}, "($(getfield(o, :properties)...))")
                 end
             end # quote
         end

--- a/src/ProtoStruct.jl
+++ b/src/ProtoStruct.jl
@@ -174,7 +174,8 @@ macro proto( expr )
                 end # function
 
                 function Base.show(io::IO, o::$name{$(type_parameter_names...)}) where {$(type_parameters...)}
-                    print(io, $name{$(type_parameter_names...)}, "($(getfield(o, :properties)...))")
+                    vals = join(getfield(a, :properties), ", ")
+                    print(io, $name{$(type_parameter_names...)}, "($vals)")
                 end
             end # quote
         end

--- a/src/ProtoStruct.jl
+++ b/src/ProtoStruct.jl
@@ -92,14 +92,14 @@ macro proto( expr )
     ex = if ismutable
             quote
                 if !@isdefined $name
-                    struct $name{P1, P2, NT<:NamedTuple} <: $abstract_type
+                    struct $name{$(type_parameters...), NT<:NamedTuple} <: $abstract_type
                         properties::NT
-                    end # struct
+                    end
                 else
                     the_methods = collect(methods($name))
                     Base.delete_method(the_methods[1])
-                    Base.delete_method(the_methods[3])
-                end # if
+                    Base.delete_method(the_methods[2])
+                end
 
                 $(
                     if type_parameters === nothing
@@ -111,17 +111,7 @@ macro proto( expr )
 
                 function $name($(fields...)) where {$(type_parameters...)} 
                     v = NamedTuple{$field_names, $field_types}(($(field_names...),))
-                    return $name{Any, Any, typeof(v)}(v)
-                end
-
-                function $name{P1}($(fields...)) where {P1,$(type_parameters...)} 
-                    v = NamedTuple{$field_names, $field_types}(($(field_names...),))
-                    return $name{P1, Any, typeof(v)}(v)
-                end
-
-                function $name{P1,P2}($(fields...)) where {P1,P2,$(type_parameters...)} 
-                    v = NamedTuple{$field_names, $field_types}(($(field_names...),))
-                    return $name{P1, P2, typeof(v)}(v)
+                    return $name{$(type_parameter_names...), typeof(v)}(v)
                 end
 
                 function $name($params_ex)
@@ -143,14 +133,14 @@ macro proto( expr )
         else
             quote
                 if !@isdefined $name
-                    struct $name{P1, P2, NT<:NamedTuple} <: $abstract_type
+                    struct $name{$(type_parameters...), NT<:NamedTuple} <: $abstract_type
                         properties::NT
-                    end # struct
+                    end
                 else
                     the_methods = collect(methods($name))
                     Base.delete_method(the_methods[1])
-                    Base.delete_method(the_methods[3])
-                end # if
+                    Base.delete_method(the_methods[2])
+                end
 
                 $(
                     if type_parameters === nothing
@@ -162,17 +152,7 @@ macro proto( expr )
 
                 function $name($(fields...)) where {$(type_parameters...)} 
                     v = NamedTuple{$field_names, $field_types}(($(field_names...),))
-                    return $name{Any, Any, typeof(v)}(v)
-                end
-
-                function $name{P1}($(fields...)) where {P1,$(type_parameters...)} 
-                    v = NamedTuple{$field_names, $field_types}(($(field_names...),))
-                    return $name{P1, Any, typeof(v)}(v)
-                end
-
-                function $name{P1,P2}($(fields...)) where {P1,P2,$(type_parameters...)} 
-                    v = NamedTuple{$field_names, $field_types}(($(field_names...),))
-                    return $name{P1, P2, typeof(v)}(v)
+                    return $name{$(type_parameter_names...), typeof(v)}(v)
                 end
 
                 function $name($params_ex)

--- a/test/test_ProtoStruct.jl
+++ b/test/test_ProtoStruct.jl
@@ -97,10 +97,17 @@ end
     tpm.E = "nope"
     @test_throws ErrorException tpm.this = "is wrong"
     @test tpm isa TestParametricMutation
+    @test tpm isa TestParametricMutation{Nothing, Float64}
+    @test !(tpm isa TestParametricMutation{Nothing, Int})
     @test tpm.A == 2
     @test tpm.B == :no
     @test tpm.C === nothing
     @test tpm.D == 1.2
     @test tpm.E == "nope"
     @test TestParametricMutation <: AbstractMutation
+    @test_throws ErrorException tpm2 = TestParametricMutation{Int, Float64}(D = 1.2, E = "yepp")
+    tpm2 = @test_nowarn TestParametricMutation{Nothing, Float64}(D = 1.2, E = "yepp")
+    @test tpm2 isa TestParametricMutation
+    @test tpm2 isa TestParametricMutation{Nothing, Float64}
+    @test !(tpm2 isa TestParametricMutation{Nothing, Int})    
 end

--- a/test/test_ProtoStruct.jl
+++ b/test/test_ProtoStruct.jl
@@ -15,7 +15,7 @@ test_me_kw = @test_nowarn TestMe(A=1, B="2", C=complex(1), D=5)
 end # testset
 
 @testset "Printing" begin
-    @test repr(test_me) == "TestMe{Complex{$Int}, $Int}(1, 2, 1 + 0im, 5)"
+    @test repr(test_me) == "TestMe{Complex{$Int}, $Int}(1, \"2\", 1 + 0im, 5)"
 end
 
 @testset "Access" begin
@@ -99,7 +99,7 @@ end
     tpm = @test_nowarn TestParametricMutation(D = 1.2, E = "yepp")
     tpm.A = 2
     tpm.E = "nope"
-    @test repr(tpm) == "TestParametricMutation{Nothing, Float64}(2, no, nothing, 1.2, nope)"
+    @test repr(tpm) == "TestParametricMutation{Nothing, Float64}(2, no, nothing, 1.2, \"nope\")"
     @test_throws ErrorException tpm.this = "is wrong"
     @test tpm isa TestParametricMutation
     @test tpm isa TestParametricMutation{Nothing, Float64}

--- a/test/test_ProtoStruct.jl
+++ b/test/test_ProtoStruct.jl
@@ -36,7 +36,7 @@ test_me_kw2 = @test_nowarn TestMe(A=1, B="2", C=complex(1), D=5, E="tadaa")
 
 
 @testset "Redefinition" begin
-    @test length(methods(TestMe)) == 3
+    @test length(methods(TestMe)) == 2
 end # testset
 
 @proto struct TestKw{T, V <: Real}

--- a/test/test_ProtoStruct.jl
+++ b/test/test_ProtoStruct.jl
@@ -88,7 +88,7 @@ end
     @test_throws MethodError tm.F = "2"
     @test propertynames(tm) == (:F, :G)
 end
-  
+
 abstract type AbstractMutation end
 
 @proto mutable struct TestParametricMutation{T, V <: Real} <: AbstractMutation
@@ -118,12 +118,26 @@ end
     tpm2 = @test_nowarn TestParametricMutation{Nothing, Float64}(D = 1.2, E = "yepp")
     @test tpm2 isa TestParametricMutation
     @test tpm2 isa TestParametricMutation{Nothing, Float64}
-    @test !(tpm2 isa TestParametricMutation{Nothing, Int})    
+    @test !(tpm2 isa TestParametricMutation{Nothing, Int})
     @test_throws MethodError tpm3 = TestParametricMutation{Int, Float64}(1, :no, nothing, 1.2, "yepp")
     tpm3 = @test_nowarn TestParametricMutation{Nothing, Float64}(1, :no, nothing, 1.2, "yepp")
     @test tpm3 isa TestParametricMutation
     @test tpm3 isa TestParametricMutation{Nothing, Float64}
     @test !(tpm3 isa TestParametricMutation{Nothing, Int})
+end
+
+@proto mutable struct TestParametricMutation{V <: Integer} <: AbstractMutation
+    A::Int = 1
+    B = :no
+    C::Nothing = nothing
+    D::V
+    E::String
+end
+
+@testset "Parametric Redefinition" begin
+    tpm = @test_nowarn TestParametricMutation(D = 1, E = "yepp")
+    @test tpm isa TestParametricMutation{Int64}
+    @test tpm isa AbstractMutation
 end
 
 @static if VERSION >= v"1.8"
@@ -133,7 +147,7 @@ end
         const C::T = 3
         D
     end
-    
+
     @testset "const fields" begin
         cf = @test_nowarn WithConstFields(D = 1.2)
         @test cf.A == 1

--- a/test/test_ProtoStruct.jl
+++ b/test/test_ProtoStruct.jl
@@ -99,7 +99,7 @@ end
     tpm = @test_nowarn TestParametricMutation(D = 1.2, E = "yepp")
     tpm.A = 2
     tpm.E = "nope"
-    @test repr(tpm) == "TestParametricMutation{Nothing, Float64}(1, 2, 1 + 0im, 5)"
+    @test repr(tpm) == "TestParametricMutation{Nothing, Float64}(2, no, nothing, 1.2, nope)"
     @test_throws ErrorException tpm.this = "is wrong"
     @test tpm isa TestParametricMutation
     @test tpm isa TestParametricMutation{Nothing, Float64}

--- a/test/test_ProtoStruct.jl
+++ b/test/test_ProtoStruct.jl
@@ -99,6 +99,7 @@ end
     tpm = @test_nowarn TestParametricMutation(D = 1.2, E = "yepp")
     tpm.A = 2
     tpm.E = "nope"
+    @test repr(tpm) == "TestParametricMutation{Nothing, Float64}(1, 2, 1 + 0im, 5)"
     @test_throws ErrorException tpm.this = "is wrong"
     @test tpm isa TestParametricMutation
     @test tpm isa TestParametricMutation{Nothing, Float64}

--- a/test/test_ProtoStruct.jl
+++ b/test/test_ProtoStruct.jl
@@ -105,12 +105,12 @@ end
     @test tpm.D == 1.2
     @test tpm.E == "nope"
     @test TestParametricMutation <: AbstractMutation
-    @test_throws ErrorException tpm2 = TestParametricMutation{Int, Float64}(D = 1.2, E = "yepp")
+    @test_throws MethodError tpm2 = TestParametricMutation{Int, Float64}(D = 1.2, E = "yepp")
     tpm2 = @test_nowarn TestParametricMutation{Nothing, Float64}(D = 1.2, E = "yepp")
     @test tpm2 isa TestParametricMutation
     @test tpm2 isa TestParametricMutation{Nothing, Float64}
     @test !(tpm2 isa TestParametricMutation{Nothing, Int})    
-    @test_throws ErrorException tpm3 = TestParametricMutation{Int, Float64}(1, :no, nothing, 1.2, "yepp")
+    @test_throws MethodError tpm3 = TestParametricMutation{Int, Float64}(1, :no, nothing, 1.2, "yepp")
     tpm3 = @test_nowarn TestParametricMutation{Nothing, Float64}(1, :no, nothing, 1.2, "yepp")
     @test tpm3 isa TestParametricMutation
     @test tpm3 isa TestParametricMutation{Nothing, Float64}

--- a/test/test_ProtoStruct.jl
+++ b/test/test_ProtoStruct.jl
@@ -15,7 +15,7 @@ test_me_kw = @test_nowarn TestMe(A=1, B="2", C=complex(1), D=5)
 end # testset
 
 @testset "Printing" begin
-    @test repr(test_me) == "TestMe{Complex{Int64}, Int64}(121 + 0im5)"
+    @test repr(test_me) == "TestMe{Complex{Int64}, Int64}(1, 2, 1 + 0im, 5)"
 end
 
 @testset "Access" begin

--- a/test/test_ProtoStruct.jl
+++ b/test/test_ProtoStruct.jl
@@ -110,4 +110,9 @@ end
     @test tpm2 isa TestParametricMutation
     @test tpm2 isa TestParametricMutation{Nothing, Float64}
     @test !(tpm2 isa TestParametricMutation{Nothing, Int})    
+    @test_throws ErrorException tpm3 = TestParametricMutation{Int, Float64}(1, :no, nothing, 1.2, "yepp")
+    tpm3 = @test_nowarn TestParametricMutation{Nothing, Float64}(1, :no, nothing, 1.2, "yepp")
+    @test tpm3 isa TestParametricMutation
+    @test tpm3 isa TestParametricMutation{Nothing, Float64}
+    @test !(tpm3 isa TestParametricMutation{Nothing, Int})  
 end

--- a/test/test_ProtoStruct.jl
+++ b/test/test_ProtoStruct.jl
@@ -14,6 +14,10 @@ test_me_kw = @test_nowarn TestMe(A=1, B="2", C=complex(1), D=5)
     @test_throws UndefKeywordError TestMe(A=1)
 end # testset
 
+@testset "Printing" begin
+    @test repr(test_me) == "TestMe{Complex{Int64}, Int64}(121 + 0im5)"
+end
+
 @testset "Access" begin
     @test test_me.A == 1
     @test test_me.B == "2"
@@ -114,5 +118,5 @@ end
     tpm3 = @test_nowarn TestParametricMutation{Nothing, Float64}(1, :no, nothing, 1.2, "yepp")
     @test tpm3 isa TestParametricMutation
     @test tpm3 isa TestParametricMutation{Nothing, Float64}
-    @test !(tpm3 isa TestParametricMutation{Nothing, Int})  
+    @test !(tpm3 isa TestParametricMutation{Nothing, Int})
 end

--- a/test/test_ProtoStruct.jl
+++ b/test/test_ProtoStruct.jl
@@ -15,7 +15,7 @@ test_me_kw = @test_nowarn TestMe(A=1, B="2", C=complex(1), D=5)
 end # testset
 
 @testset "Printing" begin
-    @test repr(test_me) == "TestMe{Complex{Int64}, Int64}(1, 2, 1 + 0im, 5)"
+    @test repr(test_me) == "TestMe{Complex{$Int}, $Int}(1, 2, 1 + 0im, 5)"
 end
 
 @testset "Access" begin

--- a/test/test_ProtoStruct.jl
+++ b/test/test_ProtoStruct.jl
@@ -10,7 +10,7 @@ test_me = @test_nowarn TestMe(1, "2", complex(1), 5)
 test_me_kw = @test_nowarn TestMe(A=1, B="2", C=complex(1), D=5)
 
 @testset "Construction" begin
-    @test TestMe((A=1,)) isa TestMe
+    @test test_me isa TestMe
     @test_throws UndefKeywordError TestMe(A=1)
 end # testset
 

--- a/test/test_ProtoStruct.jl
+++ b/test/test_ProtoStruct.jl
@@ -136,7 +136,7 @@ end
 
 @testset "Parametric Redefinition" begin
     tpm = @test_nowarn TestParametricMutation(D = 1, E = "yepp")
-    @test tpm isa TestParametricMutation{Int64}
+    @test tpm isa TestParametricMutation{Int}
     @test tpm isa AbstractMutation
 end
 


### PR DESCRIPTION
Fixes #7. Fixes #9

E.g. this now works

```julia
@proto struct pt{d}
    coords::NTuple{d,Int64}
end

pt{2}((1,1))
```