### PR TITLE
Error on redefinition of Abstract Type

### DIFF
--- a/src/ProtoStruct.jl
+++ b/src/ProtoStruct.jl
@@ -96,6 +96,7 @@ macro proto( expr )
                         properties::NT
                     end # struct
                 else
+                    $abstract_type != supertypes($name)[2] && error("The abstract type of a proto struct is not redefinable")
                     the_methods = collect(methods($name))
                     Base.delete_method(the_methods[1])
                     Base.delete_method(the_methods[3])
@@ -132,6 +133,7 @@ macro proto( expr )
                         properties::NT
                     end # struct
                 else
+                    $abstract_type != supertypes($name)[2] && error("The abstract type of a proto struct is not redefinable")
                     the_methods = collect(methods($name))
                     Base.delete_method(the_methods[1])
                     Base.delete_method(the_methods[3])


### PR DESCRIPTION
Unfortunately the abstract type is not redefinable, and I don't think there is a way to make it so, better to error then, otherwise this can happen:

```julia
using ProtoStructs
@proto struct pt{d} <: Integer
           coords::NTuple{d,Int64}
       end
pt <: Integer # true
pt <: Float64 # false
@proto struct pt{d} <: Float64
           coords::NTuple{d,Int64}
       end
pt <: Integer # true!
pt <: Float64 # false!
```


