### PR TITLE
Improve performance of mutable proto structs

### DIFF
--- a/src/ProtoStruct.jl
+++ b/src/ProtoStruct.jl
@@ -72,7 +72,7 @@ macro proto(expr)
     const_field_names = [f for (f, fi) in zip(field_names, field_info) if fi[3] == true]
 
     if ismutable
-        field_types = :(Tuple{$((:(Base.RefValue{<:$x}) for x in getindex.(field_info, 2))...)})
+        field_types = :(Tuple{$((:(Base.RefValue{$x}) for x in getindex.(field_info, 2))...)})
         fields_with_ref = (:($x=Ref($x)) for x in field_names)
     else
         field_types = :(Tuple{$(getindex.(field_info, 2)...)})


### PR DESCRIPTION
It was very slow before to do any operation on mutable proto structs, like 50x slower, which made them somewhat unusable...now they are almost as fast as normal mutable structs!

```julia
julia> using ProtoStructs

julia> @proto mutable struct A
           x::Int
           y::Int
       end

julia> mutable struct B
           x::Int
           y::Int
       end

julia> v_a = [A(x, x) for x in 1:1000];

julia> v_b = [B(x, x) for x in 1:1000];

julia> using BenchmarkTools

julia> @benchmark sum(x.y for x in $v_a)
BenchmarkTools.Trial: 10000 samples with 106 evaluations.
 Range (min … max):  820.236 ns …  1.850 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     856.915 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   864.097 ns ± 51.886 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

    ▃▄▅▄▅▇██▆▃                                                 ▂
  ▅███████████▇▄▄▅▆▇▇▇▇▇██████▇▇▆▆▆▆▆▆▆▆▅▆▆▅▅▅▅▄▅▃▂▅▂▄▂▃▅▂▄▂▅▄ █
  820 ns        Histogram: log(frequency) by time      1.08 μs <

 Memory estimate: 0 bytes, allocs estimate: 0.

julia> @benchmark sum(x.y for x in $v_b)
BenchmarkTools.Trial: 10000 samples with 92 evaluations.
 Range (min … max):  803.489 ns …  16.271 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     804.359 ns               ┊ GC (median):    0.00%
 Time  (mean ± σ):   821.656 ns ± 210.901 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

  █        ▁                                                    ▁
  █▃▃▁▃▅▄▅▆██▆▇▆▆▇▆▅▆▆▄▅▅▃▆█▄▄▅▄▄▃▄▁▄▄▄▃▃▁▁▄▃▁▃▁▄▁▄▃▁▁▄▄▄▅▃▁▃▄▅ █
  803 ns        Histogram: log(frequency) by time       1.29 μs <

 Memory estimate: 0 bytes, allocs estimate: 0.
```