### PR TITLE
Fix `show` for `const` properties of type `Vector` or `Symbol`

### DIFF
--- a/src/ProtoStruct.jl
+++ b/src/ProtoStruct.jl
@@ -161,7 +161,7 @@ macro proto(expr)
                 end
 
                 function Base.show(io::IO, o::$name)
-                    vals = join([x isa AbstractArray ? x : (isa String ? "\"$(x[])\"" : x[]) for x in getfield(o, :properties)], ", ")
+                    vals = join([x isa Base.RefValue ? (x[] isa String ? "\"$(x[])\"" : x[]) : x for x in getfield(o, :properties)], ", ")
                     params = typeof(o).parameters[1:end-$N_any_params-1]
                     if isempty(params)
                         print(io, string($name), "($vals)")

--- a/src/ProtoStruct.jl
+++ b/src/ProtoStruct.jl
@@ -161,7 +161,7 @@ macro proto(expr)
                 end
 
                 function Base.show(io::IO, o::$name)
-                    vals = join([x[] isa String ? "\"$(x[])\"" : x[] for x in getfield(o, :properties)], ", ")
+                    vals = join([x isa AbstractArray ? x : (isa String ? "\"$(x[])\"" : x[]) for x in getfield(o, :properties)], ", ")
                     params = typeof(o).parameters[1:end-$N_any_params-1]
                     if isempty(params)
                         print(io, string($name), "($vals)")

--- a/test/test_ProtoStruct.jl
+++ b/test/test_ProtoStruct.jl
@@ -161,7 +161,7 @@ end
         @test cf.A == 1
         @test cf.B == :no
         @test cf.C == 3
-        @test (show(c); true)  # test if show method errors
+        @test (show(c); true)  # test if show method works without errors
         cf.A = 5
         @test_throws ErrorException cf.B = :yes
         @test_throws ErrorException cf.C = 5

--- a/test/test_ProtoStruct.jl
+++ b/test/test_ProtoStruct.jl
@@ -161,7 +161,7 @@ end
         @test cf.A == 1
         @test cf.B == :no
         @test cf.C == 3
-        @test_nowarn show(cf)
+        @test_nowarn show(devnull, cf)
         cf.A = 5
         @test_throws ErrorException cf.B = :yes
         @test_throws ErrorException cf.C = 5

--- a/test/test_ProtoStruct.jl
+++ b/test/test_ProtoStruct.jl
@@ -153,6 +153,7 @@ end
         const B = :no
         const C::T = 3
         D
+        const E::Vector{Int} = Int[]
     end
 
     @testset "const fields" begin
@@ -160,6 +161,7 @@ end
         @test cf.A == 1
         @test cf.B == :no
         @test cf.C == 3
+        @test (show(c); true)  # test if show method errors
         cf.A = 5
         @test_throws ErrorException cf.B = :yes
         @test_throws ErrorException cf.C = 5

--- a/test/test_ProtoStruct.jl
+++ b/test/test_ProtoStruct.jl
@@ -161,7 +161,7 @@ end
         @test cf.A == 1
         @test cf.B == :no
         @test cf.C == 3
-        @test (show(c); true)  # test if show method works without errors
+        @test_nowarn show(cf)
         cf.A = 5
         @test_throws ErrorException cf.B = :yes
         @test_throws ErrorException cf.C = 5


### PR DESCRIPTION
It seems that 
```julia
@proto mutable struct Foo
    const x::Vector{Int} = Int[]
end

show(Foo())
```
causes an error since `x` will neither be a `Base.RefValue` nor a `String`. 

This two-line PR should fix this. 