### PR TITLE
Add length check guards for delete methods

### DIFF
--- a/src/ProtoStruct.jl
+++ b/src/ProtoStruct.jl
@@ -116,8 +116,12 @@ macro proto(expr)
                         error("The supertype of a proto struct is not redefinable. Please restart your julia session.")
                     end
                     the_methods = collect(methods($name))
-                    Base.delete_method(the_methods[1])
-                    Base.delete_method(the_methods[2])
+                    if length(the_methods) >= 1
+                        Base.delete_method(the_methods[1])
+                    end
+                    if length(the_methods) >= 2
+                        Base.delete_method(the_methods[2])
+                    end
                 end
 
                 function $name($(fields...)) where {$(type_parameters...)}
@@ -181,8 +185,12 @@ macro proto(expr)
                         error("The supertype of a proto struct is not redefinable. Please restart your julia session.")
                     end
                     the_methods = collect(methods($name))
-                    Base.delete_method(the_methods[1])
-                    Base.delete_method(the_methods[2])
+                    if length(the_methods) >= 1
+                        Base.delete_method(the_methods[1])
+                    end
+                    if length(the_methods) >= 2
+                        Base.delete_method(the_methods[2])
+                    end
                 end
 
                 function $name($(fields...)) where {$(type_parameters...)}

--- a/test/test_ProtoStruct.jl
+++ b/test/test_ProtoStruct.jl
@@ -167,3 +167,13 @@ end
         @test_throws ErrorException cf.C = 5
     end
 end
+
+@testset "Constuctor updating"
+    @proto struct TestMethods end
+    @test length(collect(methods(TestMethods))) == 1
+    @test_nowarn @proto struct TestMethods
+        a
+        b
+    end
+    @test length(collect(methods(TestMethods))) == 2
+end

--- a/test/test_ProtoStruct.jl
+++ b/test/test_ProtoStruct.jl
@@ -168,7 +168,7 @@ end
     end
 end
 
-@testset "Constuctor updating"
+@testset "Constuctor updating" begin
     @proto struct TestMethods end
     @test length(collect(methods(TestMethods))) == 1
     @test_nowarn @proto struct TestMethods

--- a/test/test_ProtoStruct.jl
+++ b/test/test_ProtoStruct.jl
@@ -170,12 +170,16 @@ end
 
 @proto struct TestMethods end
 
-@testset "Constuctor updating" begin
+@testset "Constuctor updating I" begin
     @test length(collect(methods(TestMethods))) == 1
-    @test_nowarn @proto struct TestMethods
+end
+
+@test_nowarn @proto struct TestMethods
         a
         b
-    end
+end
+
+@testset "Constuctor updating II" begin
     @test length(collect(methods(TestMethods))) == 2
 end
 

--- a/test/test_ProtoStruct.jl
+++ b/test/test_ProtoStruct.jl
@@ -168,8 +168,9 @@ end
     end
 end
 
+@proto struct TestMethods end
+
 @testset "Constuctor updating" begin
-    @proto struct TestMethods end
     @test length(collect(methods(TestMethods))) == 1
     @test_nowarn @proto struct TestMethods
         a

--- a/test/test_ProtoStruct.jl
+++ b/test/test_ProtoStruct.jl
@@ -174,7 +174,7 @@ end
     @test length(collect(methods(TestMethods))) == 1
 end
 
-@test_nowarn @proto struct TestMethods
+@proto struct TestMethods
         a
         b
 end


### PR DESCRIPTION
This fixed #13 for me. ~It seems like a safe solution, since there's no harm in deleting all existing methods that may be around as they will all be redefined subsequently -- but let me know if you foresee any issues.~

Update; the PR now just adds length check guards, which should be an improvement over the previous behaviour although an issue should be created for the assumption on index 1 and 2