### PR TITLE
Create :revisable flag for compatibility with Revise

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,7 @@ Redefine at will, but remove the `@proto` macro after developing to ensure corre
 
 ## Compatibility with Revise.jl
 
-For workflows using `Revise.jl` use the `@revisableproto` macro. This works almost equivalently to `@proto`
-except that docstring can't be attached to structs.
-
+For workflows using `Revise.jl` use the `@proto` macro passing `:revisable` as first argument. 
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ c = DevType(2, 4.0, nothing)
 
 Redefine at will, but remove the `@proto` macro after developing to ensure correctness and improve performance of your code.
 
-# Compatibility with Revise.jl
+## Compatibility with Revise.jl
 
 For workflows using `Revise.jl` use the `@revisableproto` macro. This works almost equivalently to `@proto`
 except that docstring can't be attached to structs.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ c = DevType(2, 4.0, nothing)
 
 Redefine at will, but remove the `@proto` macro after developing to ensure correctness and improve performance of your code.
 
+# Compatibility with Revise.jl
+
+For workflows using `Revise.jl` use the `@revisableproto` macro. This works almost equivalently to `@proto`
+except that docstring can't be attached to structs.
 
 
 ---

--- a/src/ProtoStruct.jl
+++ b/src/ProtoStruct.jl
@@ -1,5 +1,14 @@
 
+macro revisableproto(expr)
+    @eval __module__ $(_proto(expr))
+    return
+end
+
 macro proto(expr)
+    return esc(_proto(expr))
+end
+
+function _proto(expr)
     if expr.head == :macrocall && expr.args[1] == Symbol("@kwdef")
         expr = expr.args[3]
     end
@@ -230,6 +239,6 @@ macro proto(expr)
                 end
             end
         end
-    return esc(ex)
+    return ex
 end
 

--- a/src/ProtoStruct.jl
+++ b/src/ProtoStruct.jl
@@ -1,7 +1,13 @@
 
-macro revisableproto(expr)
-    @eval __module__ $(_proto(expr))
-    return
+macro proto(revisable, expr)
+    if revisable == QuoteNode(:revisable)
+        @eval __module__ $(_proto(expr))
+        return
+    elseif revisable == QuoteNode(:standard)
+        return esc(_proto(expr))
+    else
+        error("Version not recognized: use :standard or :revisable")
+    end
 end
 
 macro proto(expr)
@@ -241,4 +247,3 @@ function _proto(expr)
         end
     return ex
 end
-

--- a/src/ProtoStructs.jl
+++ b/src/ProtoStructs.jl
@@ -1,6 +1,6 @@
 module ProtoStructs
 
-export @proto, @revisableproto
+export @proto
 
 include("ProtoStruct.jl")
 

--- a/src/ProtoStructs.jl
+++ b/src/ProtoStructs.jl
@@ -1,6 +1,6 @@
 module ProtoStructs
 
-export @proto
+export @proto, @revisableproto
 
 include("ProtoStruct.jl")
 

--- a/test/test_ProtoStruct.jl
+++ b/test/test_ProtoStruct.jl
@@ -196,11 +196,11 @@ end
 
 # revisableproto macro tests
 
-@revisableproto struct SimpleTestMe2
+@proto :revisable struct SimpleTestMe2
     A::Int
 end
 
-@revisableproto struct TestMe2{T, V <: Real}
+@proto :revisable struct TestMe2{T, V <: Real}
     A::Int
     B
     C::T
@@ -229,7 +229,7 @@ end
     @test propertynames(test_me) == (:A, :B, :C, :D)
 end
 
-@revisableproto struct TestMe2{T, V <: Real}
+@proto :revisable struct TestMe2{T, V <: Real}
     A::Int
     B
     C::T
@@ -243,7 +243,7 @@ test_me_kw2 = @test_nowarn TestMe2(A=1, B="2", C=complex(1), D=5, E="tadaa")
     @test length(methods(TestMe2)) == 2
 end
 
-@revisableproto struct TestKw2{T, V <: Real}
+@proto :revisable struct TestKw2{T, V <: Real}
     A::Int = 1
     B = :no
     C::T = nothing
@@ -261,7 +261,7 @@ end
     @test tw.E == "yepp"
 end
 
-@revisableproto @kwdef struct TestMacroOutside2
+@proto :revisable @kwdef struct TestMacroOutside2
     A::Int = 1
 end
 
@@ -287,7 +287,7 @@ end
 
 abstract type AbstractMutation2 end
 
-@revisableproto mutable struct TestParametricMutation2{T, V <: Real} <: AbstractMutation2
+@proto :revisable mutable struct TestParametricMutation2{T, V <: Real} <: AbstractMutation2
     A::Int = 1
     B = :no
     C::T = nothing
@@ -322,7 +322,7 @@ end
     @test !(tpm3 isa TestParametricMutation2{Nothing, Int})
 end
 
-@revisableproto mutable struct TestParametricMutation2{V <: Integer} <: AbstractMutation2
+@proto :revisable mutable struct TestParametricMutation2{V <: Integer} <: AbstractMutation2
     A::Int = 1
     B = :no
     C::Nothing = nothing
@@ -337,7 +337,7 @@ end
 end
 
 @static if VERSION >= v"1.8"
-    @revisableproto mutable struct WithConstFields2{T}
+    @proto :revisable mutable struct WithConstFields2{T}
         A::Int = 1
         const B = :no
         const C::T = 3
@@ -357,13 +357,13 @@ end
     end
 end
 
-@revisableproto struct TestMethods2 end
+@proto :revisable struct TestMethods2 end
 
 @testset "Constuctor updating I" begin
     @test length(collect(methods(TestMethods2))) == 1
 end
 
-@revisableproto struct TestMethods2
+@proto :revisable struct TestMethods2
         a
         b
 end
@@ -371,4 +371,3 @@ end
 @testset "Constuctor updating II" begin
     @test length(collect(methods(TestMethods2))) == 2
 end
-

--- a/test/test_ProtoStruct.jl
+++ b/test/test_ProtoStruct.jl
@@ -193,3 +193,182 @@ end
 @testset "Docstring" begin
     @test string(@doc DocTestMe) == "This is a docstring.\n"
 end
+
+# revisableproto macro tests
+
+@revisableproto struct SimpleTestMe2
+    A::Int
+end
+
+@revisableproto struct TestMe2{T, V <: Real}
+    A::Int
+    B
+    C::T
+    D::V
+end
+test_me = @test_nowarn TestMe2(1, "2", complex(1), 5)
+test_me_kw = @test_nowarn TestMe2(A=1, B="2", C=complex(1), D=5)
+
+@testset "Construction" begin
+    @test SimpleTestMe2(1) isa SimpleTestMe2
+    @test test_me isa TestMe2
+    @test_throws UndefKeywordError TestMe2(A=1)
+end
+
+@testset "Printing" begin
+    @test repr(test_me) == "TestMe2{Complex{$Int}, $Int}(1, \"2\", 1 + 0im, 5)"
+end
+
+@testset "Access" begin
+    @test test_me.A == 1
+    @test test_me.B == "2"
+    @test test_me.C == complex(1)
+end
+
+@testset "Properties" begin
+    @test propertynames(test_me) == (:A, :B, :C, :D)
+end
+
+@revisableproto struct TestMe2{T, V <: Real}
+    A::Int
+    B
+    C::T
+    D::V
+    E::String
+end
+test_me2 = @test_nowarn TestMe2(1, "2", complex(1), 5, "tadaa")
+test_me_kw2 = @test_nowarn TestMe2(A=1, B="2", C=complex(1), D=5, E="tadaa")
+
+@testset "Redefinition" begin
+    @test length(methods(TestMe2)) == 2
+end
+
+@revisableproto struct TestKw2{T, V <: Real}
+    A::Int = 1
+    B = :no
+    C::T = nothing
+    D::V
+    E::String
+end
+
+@testset "kwdef" begin
+    tw = TestKw2(D = 1.2, E = "yepp")
+    @test tw isa TestKw2
+    @test tw.A == 1
+    @test tw.B == :no
+    @test tw.C === nothing
+    @test tw.D == 1.2
+    @test tw.E == "yepp"
+end
+
+@revisableproto @kwdef struct TestMacroOutside2
+    A::Int = 1
+end
+
+@testset "@kwdef macro outside" begin
+    tw = TestMacroOutside2()
+    @test tw isa TestMacroOutside2
+    @test tw.A == 1
+end
+
+@proto mutable struct TestMutation2
+    F::Int
+    G::Float64
+end
+
+@testset "Mutation" begin
+    tm = @test_nowarn TestMutation2(4, 2.0)
+    @test tm.F == 4 && tm.G == 2.0
+    tm.F = 8
+    @test tm.F == 8 && tm.G == 2.0
+    @test_throws MethodError tm.F = "2"
+    @test propertynames(tm) == (:F, :G)
+end
+
+abstract type AbstractMutation2 end
+
+@revisableproto mutable struct TestParametricMutation2{T, V <: Real} <: AbstractMutation2
+    A::Int = 1
+    B = :no
+    C::T = nothing
+    D::V
+    E::String
+end
+
+@testset "Parametric Mutation" begin
+    tpm = @test_nowarn TestParametricMutation2(D = 1.2, E = "yepp")
+    tpm.A = 2
+    tpm.E = "nope"
+    @test repr(tpm) == "TestParametricMutation2{Nothing, Float64}(2, no, nothing, 1.2, \"nope\")"
+    @test_throws ErrorException tpm.this = "is wrong"
+    @test tpm isa TestParametricMutation2
+    @test tpm isa TestParametricMutation2{Nothing, Float64}
+    @test !(tpm isa TestParametricMutation2{Nothing, Int})
+    @test tpm.A == 2
+    @test tpm.B == :no
+    @test tpm.C === nothing
+    @test tpm.D == 1.2
+    @test tpm.E == "nope"
+    @test TestParametricMutation2 <: AbstractMutation2
+    @test_throws MethodError tpm2 = TestParametricMutation2{Int, Float64}(D = 1.2, E = "yepp")
+    tpm2 = @test_nowarn TestParametricMutation2{Nothing, Float64}(D = 1.2, E = "yepp")
+    @test tpm2 isa TestParametricMutation2
+    @test tpm2 isa TestParametricMutation2{Nothing, Float64}
+    @test !(tpm2 isa TestParametricMutation2{Nothing, Int})
+    @test_throws MethodError tpm3 = TestParametricMutation2{Int, Float64}(1, :no, nothing, 1.2, "yepp")
+    tpm3 = @test_nowarn TestParametricMutation2{Nothing, Float64}(1, :no, nothing, 1.2, "yepp")
+    @test tpm3 isa TestParametricMutation2
+    @test tpm3 isa TestParametricMutation2{Nothing, Float64}
+    @test !(tpm3 isa TestParametricMutation2{Nothing, Int})
+end
+
+@revisableproto mutable struct TestParametricMutation2{V <: Integer} <: AbstractMutation2
+    A::Int = 1
+    B = :no
+    C::Nothing = nothing
+    D::V
+    E::String
+end
+
+@testset "Parametric Redefinition" begin
+    tpm = @test_nowarn TestParametricMutation2(D = 1, E = "yepp")
+    @test tpm isa TestParametricMutation2{Int}
+    @test tpm isa AbstractMutation2
+end
+
+@static if VERSION >= v"1.8"
+    @revisableproto mutable struct WithConstFields2{T}
+        A::Int = 1
+        const B = :no
+        const C::T = 3
+        D
+        const E::Vector{Int} = Int[]
+    end
+
+    @testset "const fields" begin
+        cf = @test_nowarn WithConstFields2(D = 1.2)
+        @test cf.A == 1
+        @test cf.B == :no
+        @test cf.C == 3
+        @test_nowarn show(devnull, cf)
+        cf.A = 5
+        @test_throws ErrorException cf.B = :yes
+        @test_throws ErrorException cf.C = 5
+    end
+end
+
+@revisableproto struct TestMethods2 end
+
+@testset "Constuctor updating I" begin
+    @test length(collect(methods(TestMethods2))) == 1
+end
+
+@revisableproto struct TestMethods2
+        a
+        b
+end
+
+@testset "Constuctor updating II" begin
+    @test length(collect(methods(TestMethods2))) == 2
+end
+

--- a/test/test_ProtoStruct.jl
+++ b/test/test_ProtoStruct.jl
@@ -186,7 +186,7 @@ end
 """
 This is a docstring.
 """
-@proto struct DocTestMe
+@proto :standard struct DocTestMe
     A::Int
 end
 


### PR DESCRIPTION
Fixes #13 

The example provided by @Eben60 works with revisableproto, as well as all tests except for the docstring one. For this reason, I created this new version. 