### PR TITLE
Use different version if Revise is tracking proto

### DIFF
--- a/src/ProtoStruct.jl
+++ b/src/ProtoStruct.jl
@@ -6,10 +6,8 @@ function checkrev()
     revise_pkgid in keys(Base.loaded_modules) || return false 
     d = @__DIR__ 
     f = splitpath(@__FILE__)[end]
-
     watched_files = getproperty(Base.loaded_modules[revise_pkgid], :watched_files)
     d in keys(watched_files) || return false
-
     trackedfiles = watched_files[d].trackedfiles
     return f in keys(trackedfiles)
 end


### PR DESCRIPTION
Alternative to #35. Look at https://discourse.julialang.org/t/is-there-a-way-to-know-if-revise-is-enabled/110379/6 for the limitations. Thanks to @Eben60 for the most part of the implementation (need to add him as a coauthor at least). It works fine on my machine

Fixes #13 
Closes #35 