### PR TITLE
upgrade changed struct fields, cvt values, use NT for field_info

### DIFF
--- a/src/ProtoStruct.jl
+++ b/src/ProtoStruct.jl
@@ -331,36 +331,36 @@ function updateproto(o::T) where {T}
     return true
 end
 
-function updatefield(o, oldfields, (; name, type, isconst, hasdefault, default))
+function updatefield(o, oldfields, info)
     local err = ""
-    local orig_type = type
+    local orig_type = info.type
 
-    if type isa Integer
-        type = typeof(o).parameters[type]
+    if info.type isa Integer
+        info.type = typeof(o).parameters[info.type]
     end
-    if !isconst
-        type = Ref{type}
+    if !info.isconst
+        info.type = Ref{info.type}
     end
-    if name ∈ keys(oldfields)
+    if info.name ∈ keys(oldfields)
         try
-            return updatevalue(type, oldfields[name])
+            return updatevalue(info.type, oldfields[info.name])
         catch
-            err = "Could not convert old value $(oldfields[name]) to type $type"
+            err = "Could not convert old value $(oldfields[info.name]) to type $info.type"
         end
     end
-    if !hasdefault
+    if !info.hasdefault
         try
-            default = typemin(orig_type)
+            info.default = typemin(orig_type)
             if !isempty(err)
-                err = "$err and no default value for field $name, choosing typemin"
+                err = "$err and no default value for field $info.name, choosing typemin"
             else
-                err = "No default value for field $name, choosing typemin"
+                err = "No default value for field $info.name, choosing typemin"
             end
         catch
             if !isempty(err)
-                error("$err and no default value or typemin for field $name")
+                error("$err and no default value or typemin for field $info.name")
             else
-                error("No default value or typemin for field $name")
+                error("No default value or typemin for field $info.name")
             end
         end
     elseif !isempty(err)
@@ -368,7 +368,7 @@ function updatefield(o, oldfields, (; name, type, isconst, hasdefault, default))
     end
     !isempty(err) &&
         @warn err
-    return default
+    return info.default
 end
 
 updatevalue(newtype, value) = convert(newtype, value)

--- a/src/ProtoStruct.jl
+++ b/src/ProtoStruct.jl
@@ -95,7 +95,7 @@ function _proto(expr)
                   )
 
     field_names = keys(field_info)
-    const_field_names = [name for (; name, isconst) in field_info if isconst]
+    const_field_names = [name for (; name=name, isconst=isconst) in field_info if isconst]
 
     if ismutable
         field_types = :(Tuple{$((isconst ? :($type where {$type}) : :(Base.RefValue{$type} where {$type})

--- a/src/ProtoStruct.jl
+++ b/src/ProtoStruct.jl
@@ -95,7 +95,7 @@ function _proto(expr)
                   )
 
     field_names = keys(field_info)
-    const_field_names = [info.name for info in field_info if isconst]
+    const_field_names = [info.name for info in field_info if info.isconst]
 
     if ismutable
         field_types = :(Tuple{$((info.isconst ? :($(info.type) where {$(info.type)}) :
@@ -300,7 +300,7 @@ end
 
 function runtime_field_info(info, params)
     return :((;
-              $((:($name = (; name = $(QuoteNode(i.name)),
+              $((:($(i.name) = (; name = $(QuoteNode(i.name)),
                             type = $(protofieldtype(i.type, params)), isconst = $(i.isconst),
                             hasdefault = $(i.hasdefault), default = $(i.default)))
                  for i in info)...),

--- a/test/test_ProtoStruct.jl
+++ b/test/test_ProtoStruct.jl
@@ -186,7 +186,7 @@ end
     @test length(collect(methods(TestMethods))) == 2
 end
 
-@static if VERSION <= v"1.10"
+@static if VERSION == v"1.10"
 
 """
 This is a docstring.

--- a/test/test_ProtoStruct.jl
+++ b/test/test_ProtoStruct.jl
@@ -171,6 +171,8 @@ end
     end
 end
 
+@static if VERSION <= v"1.10"
+
 @proto struct TestMethods end
 
 @testset "Constuctor updating I" begin
@@ -184,6 +186,8 @@ end
 
 @testset "Constuctor updating II" begin
     @test length(collect(methods(TestMethods))) == 2
+end
+
 end
 
 @static if VERSION == v"1.10"

--- a/test/test_ProtoStruct.jl
+++ b/test/test_ProtoStruct.jl
@@ -193,3 +193,26 @@ end
 @testset "Docstring" begin
     @test string(@doc DocTestMe) == "This is a docstring.\n"
 end
+
+@proto @kwdef struct A{T}
+    x::Array{T} = T[]
+end
+
+a = A{Int}()
+
+@test a.x == []
+
+@proto @kwdef struct A{T}
+    x::Array{T} = T[]
+    y::Int = 3
+end
+
+@test a.y == 3
+
+@test A(; x = ["hello"]).x == ["hello"]
+
+@proto @kwdef struct A{T}
+    y::Int = 3
+end
+
+@test_throws ErrorException a.x

--- a/test/test_ProtoStruct.jl
+++ b/test/test_ProtoStruct.jl
@@ -87,6 +87,9 @@ end
     @test tm.F == 8 && tm.G == 2.0
     @test_throws MethodError tm.F = "2"
     @test propertynames(tm) == (:F, :G)
+    # value conversion
+    tm.G = 8
+    @test tm.G == 8.0
 end
 
 abstract type AbstractMutation end
@@ -183,6 +186,8 @@ end
     @test length(collect(methods(TestMethods))) == 2
 end
 
+@static if VERSION <= v"1.10"
+
 """
 This is a docstring.
 """
@@ -193,6 +198,8 @@ end
 @testset "Docstring" begin
     @test string(@doc DocTestMe) == "This is a docstring.\n"
 end
+    
+end
 
 @proto @kwdef struct A{T}
     x::Array{T} = T[]
@@ -201,6 +208,10 @@ end
 a = A{Int}()
 
 @test a.x == []
+
+a = A(; x = Int64[])
+
+@test typeof(a).parameters[1] == Int64
 
 @proto @kwdef struct A{T}
     x::Array{T} = T[]
@@ -212,7 +223,9 @@ end
 @test A(; x = ["hello"]).x == ["hello"]
 
 @proto @kwdef struct A{T}
-    y::Int = 3
+    y::Float64 = 3
 end
 
 @test_throws ErrorException a.x
+@test a.y == 3.0
+@test A{:florp}(;y = Int(1)).y === 1.0


### PR DESCRIPTION
Fixes https://github.com/BeastyBlacksmith/ProtoStructs.jl/issues/40

This PR removes / adds / converts fields in existing structs when the struct definition changes. It does this by
1. Changing `properties` to be a ref so it can be reassigned
2. Removing the NT type parameter so that assigning a new properties NT can work
3. Adding info to each proto struct that tracks the current shape, world counter, and type params at creation time
4. Placing an `updateproto` call at the top of the generated methods to check for updates based on the world field

Also, this adds type conversion to the generated constructors.