### PR TITLE
load REPL in test and copy `Base._kwdef!`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,6 @@ authors = ["Simon Christ"]
 version = "1.2.0"
 
 [compat]
-REPL = "1.11.0"
 julia = "1.6"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -4,10 +4,12 @@ authors = ["Simon Christ"]
 version = "1.2.0"
 
 [compat]
+REPL = "1.11.0"
 julia = "1.6"
 
 [extras]
+REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["Test", "REPL"]

--- a/test/test_ProtoStruct.jl
+++ b/test/test_ProtoStruct.jl
@@ -1,4 +1,5 @@
 using ProtoStructs, Test
+using REPL # needs to be loaded in julia >= 1.11 to let docstring test pass
 
 @proto struct SimpleTestMe
     A::Int


### PR DESCRIPTION
This is a workaround for #44 

Loading REPL in the tests became necessary because of https://github.com/JuliaLang/julia/issues/54664